### PR TITLE
Fix to plugin load and listing in CS#

### DIFF
--- a/Extensions/AssemblyInfoEx.cs
+++ b/Extensions/AssemblyInfoEx.cs
@@ -6,15 +6,8 @@ namespace DoubleJumpCS2.Extensions
     {
         public static string GetVersion()
         {
-            /*return Assembly
-                .GetExecutingAssembly()
-                .GetCustomAttribute<AssemblyVersionAttribute>()
-                .Version;*/
-            
-            
-            var version = typeof(AssemblyInfoEx).Assembly
+            return typeof(AssemblyInfoEx).Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-            return version ?? "1.0.0"; // Default version if not found
         }
 
         public static string GetAuthor()

--- a/Extensions/AssemblyInfoEx.cs
+++ b/Extensions/AssemblyInfoEx.cs
@@ -6,10 +6,15 @@ namespace DoubleJumpCS2.Extensions
     {
         public static string GetVersion()
         {
-            return Assembly
+            /*return Assembly
                 .GetExecutingAssembly()
                 .GetCustomAttribute<AssemblyVersionAttribute>()
-                .Version;
+                .Version;*/
+            
+            
+            var version = typeof(AssemblyInfoEx).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            return version ?? "1.0.0"; // Default version if not found
         }
 
         public static string GetAuthor()


### PR DESCRIPTION
This pull request addresses the overall functionality and listing of the plugin in CS2 servers running CS#.

The way the version was being obtained from the csproj file, PropertyGroup >> Version property, would cause an attempt of a null dereference. Therefore, the plugin wouldn't work properly and would cause the whole CS# plugin list to break, as the GetVersion method would throw an error.

This has been tested with MM 2.0.0-dev+1293 and CS# v259. The plugin was still compiled with the CS# version from the latest build, v240.

Regards!